### PR TITLE
Rename interface to gcp-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This layer encapsulates the `gcp-integration` interface communciation protocol
+This layer encapsulates the `gcp-integration` interface communication protocol
 and provides an API for charms on either side of relations using this
 interface.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # Overview
 
-This layer encapsulates the `gcp` interface communciation protocol and provides
-an API for charms on either side of relations using this interface.
+This layer encapsulates the `gcp-integration` interface communciation protocol
+and provides an API for charms on either side of relations using this
+interface.
 
 ## Usage
 
-In your charm's `layer.yaml`, ensure that `interface:gcp` is included in the
-`includes` section:
+In your charm's `layer.yaml`, ensure that `interface:gcp-integration` is
+included in the `includes` section:
 
 ```yaml
-includes: ['layer:basic', 'interface:gcp']
+includes: ['layer:basic', 'interface:gcp-integration']
 ```
 
 And in your charm's `metadata.yaml`, ensure that a relation endpoint is defined
-using the `gcp` interface protocol:
+using the `gcp-integration` interface protocol:
 
 ```yaml
 requires:
   gcp:
-    interface: gcp
+    interface: gcp-integration
 ```
 
 For documentation on how to use the API for this interface, see:
 
 * [Requires API documentation](docs/requires.md)
-* [Provides API documentation](docs/provides.md) (this will only be used by the GCP charm)
+* [Provides API documentation](docs/provides.md) (this will only be used by the gcp-integrator charm)

--- a/docs/provides.md
+++ b/docs/provides.md
@@ -12,10 +12,10 @@ The flags that are set by the provides side of this interface are:
   whatever actions are necessary to satisfy those requests, and then mark
   them as complete.
 
-<h1 id="provides.GCPProvides">GCPProvides</h1>
+<h1 id="provides.GCPIntegrationProvides">GCPIntegrationProvides</h1>
 
 ```python
-GCPProvides(self, endpoint_name, relation_ids=None)
+GCPIntegrationProvides(self, endpoint_name, relation_ids=None)
 ```
 
 Example usage:
@@ -43,30 +43,30 @@ def handle_requests():
     gcp.mark_completed()
 ```
 
-<h2 id="provides.GCPProvides.relation_ids">relation_ids</h2>
+<h2 id="provides.GCPIntegrationProvides.relation_ids">relation_ids</h2>
 
 
 A list of the IDs of all established relations.
 
-<h2 id="provides.GCPProvides.requests">requests</h2>
+<h2 id="provides.GCPIntegrationProvides.requests">requests</h2>
 
 
 A list of the new or updated `IntegrationRequests` that
 have been made.
 
-<h2 id="provides.GCPProvides.get_departed_charms">get_departed_charms</h2>
+<h2 id="provides.GCPIntegrationProvides.get_departed_charms">get_departed_charms</h2>
 
 ```python
-GCPProvides.get_departed_charms(self)
+GCPIntegrationProvides.get_departed_charms(self)
 ```
 
 Get a list of all charms that have had all units depart since the
 last time this was called.
 
-<h2 id="provides.GCPProvides.mark_completed">mark_completed</h2>
+<h2 id="provides.GCPIntegrationProvides.mark_completed">mark_completed</h2>
 
 ```python
-GCPProvides.mark_completed(self)
+GCPIntegrationProvides.mark_completed(self)
 ```
 
 Mark all requests as completed and remove the `requests-pending` flag.

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -19,10 +19,10 @@ The flags that are set by the requires side of this interface are:
   running.  This flag is automatically removed if new integration features
   are requested.  It should not be removed by the charm.
 
-<h1 id="requires.GCPRequires">GCPRequires</h1>
+<h1 id="requires.GCPIntegrationRequires">GCPIntegrationRequires</h1>
 
 ```python
-GCPRequires(self, *args, **kwargs)
+GCPIntegrationRequires(self, *args, **kwargs)
 ```
 
 Interface to request integration access.
@@ -55,25 +55,25 @@ def gcp_integration_ready():
     update_config_enable_gcp()
 ```
 
-<h2 id="requires.GCPRequires.instance">instance</h2>
+<h2 id="requires.GCPIntegrationRequires.instance">instance</h2>
 
 
 This unit's instance name.
 
-<h2 id="requires.GCPRequires.is_ready">is_ready</h2>
+<h2 id="requires.GCPIntegrationRequires.is_ready">is_ready</h2>
 
 
 Whether or not the request for this instance has been completed.
 
-<h2 id="requires.GCPRequires.zone">zone</h2>
+<h2 id="requires.GCPIntegrationRequires.zone">zone</h2>
 
 
 The zone this unit is in.
 
-<h2 id="requires.GCPRequires.label_instance">label_instance</h2>
+<h2 id="requires.GCPIntegrationRequires.label_instance">label_instance</h2>
 
 ```python
-GCPRequires.label_instance(self, labels)
+GCPIntegrationRequires.label_instance(self, labels)
 ```
 
 Request that the given labels be applied to this instance.
@@ -82,58 +82,58 @@ __Parameters__
 
 - __`labels` (dict)__: Mapping of labels names to values.
 
-<h2 id="requires.GCPRequires.enable_instance_inspection">enable_instance_inspection</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_instance_inspection">enable_instance_inspection</h2>
 
 ```python
-GCPRequires.enable_instance_inspection(self)
+GCPIntegrationRequires.enable_instance_inspection(self)
 ```
 
 Request the ability to inspect instances.
 
-<h2 id="requires.GCPRequires.enable_network_management">enable_network_management</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_network_management">enable_network_management</h2>
 
 ```python
-GCPRequires.enable_network_management(self)
+GCPIntegrationRequires.enable_network_management(self)
 ```
 
 Request the ability to manage networking.
 
-<h2 id="requires.GCPRequires.enable_security_management">enable_security_management</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_security_management">enable_security_management</h2>
 
 ```python
-GCPRequires.enable_security_management(self)
+GCPIntegrationRequires.enable_security_management(self)
 ```
 
 Request the ability to manage security (e.g., firewalls).
 
-<h2 id="requires.GCPRequires.enable_block_storage_management">enable_block_storage_management</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_block_storage_management">enable_block_storage_management</h2>
 
 ```python
-GCPRequires.enable_block_storage_management(self)
+GCPIntegrationRequires.enable_block_storage_management(self)
 ```
 
 Request the ability to manage block storage.
 
-<h2 id="requires.GCPRequires.enable_dns_management">enable_dns_management</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_dns_management">enable_dns_management</h2>
 
 ```python
-GCPRequires.enable_dns_management(self)
+GCPIntegrationRequires.enable_dns_management(self)
 ```
 
 Request the ability to manage DNS.
 
-<h2 id="requires.GCPRequires.enable_object_storage_access">enable_object_storage_access</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_object_storage_access">enable_object_storage_access</h2>
 
 ```python
-GCPRequires.enable_object_storage_access(self)
+GCPIntegrationRequires.enable_object_storage_access(self)
 ```
 
 Request the ability to access object storage.
 
-<h2 id="requires.GCPRequires.enable_object_storage_management">enable_object_storage_management</h2>
+<h2 id="requires.GCPIntegrationRequires.enable_object_storage_management">enable_object_storage_management</h2>
 
 ```python
-GCPRequires.enable_object_storage_management(self)
+GCPIntegrationRequires.enable_object_storage_management(self)
 ```
 
 Request the ability to manage object storage.

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
-name: gcp
-summary: Interface for connecting to the GCP integration charm.
+name: gcp-integration
+summary: Interface for connecting to the GCP integrator charm.
 version: 1
 maintainer: Cory Johns <cory.johns@canonical.com>

--- a/make_docs
+++ b/make_docs
@@ -8,8 +8,10 @@ import pydocmd.__main__
 
 
 with patch('charmhelpers.core.hookenv.metadata') as metadata:
-    metadata.return_value = {'requires': {'gcp': {'interface': 'gcp'}},
-                             'provides': {'gcp': {'interface': 'gcp'}}}
+    metadata.return_value = {
+        'requires': {'gcp': {'interface': 'gcp-integration'}},
+        'provides': {'gcp': {'interface': 'gcp-integration'}},
+    }
     sys.path.insert(0, '.')
     print(sys.argv)
     if len(sys.argv) == 1:

--- a/provides.py
+++ b/provides.py
@@ -18,7 +18,7 @@ from charms.reactive import when
 from charms.reactive import toggle_flag, clear_flag
 
 
-class GCPProvides(Endpoint):
+class GCPIntegrationProvides(Endpoint):
     """
     Example usage:
 

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -3,10 +3,10 @@ site_name: 'GCP Integration Interface'
 generate:
   - requires.md:
     - requires
-    - requires.GCPRequires+
+    - requires.GCPIntegrationRequires+
   - provides.md:
     - provides
-    - provides.GCPProvides+
+    - provides.GCPIntegrationProvides+
     - provides.IntegrationRequest+
 
 pages:

--- a/requires.py
+++ b/requires.py
@@ -38,7 +38,7 @@ from charms.reactive import clear_flag, toggle_flag
 READ_BLOCK_SIZE = 2048
 
 
-class GCPRequires(Endpoint):
+class GCPIntegrationRequires(Endpoint):
     """
     Interface to request integration access.
 


### PR DESCRIPTION
With the creation of the OpenStack integrator charm, it has become clear that the bare cloud name is a confusing naming convention.  So we're renaming the charms to `-integrator` and the interfaces to `-integration`.